### PR TITLE
Staging

### DIFF
--- a/src/core/integrations/sentry.ts
+++ b/src/core/integrations/sentry.ts
@@ -1,22 +1,20 @@
 import * as Sentry from '@sentry/react';
-import { Replay } from '@sentry/react';
 
 const apiUrl = process.env.REACT_APP_API_URL ?? '';
 
 const initSentry = (): void => {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
-    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay({
+      networkDetailAllowUrls: [window.location.origin, apiUrl],
+    })],
     tracesSampleRate: .5,
-    replaysSessionSampleRate: .5,
+    replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: .5,
     environment: process.env.REACT_APP_ENVIRONMENT,
   })
 }
 
-// eslint-disable-next-line no-new
-new Replay({
-  networkDetailAllowUrls: [window.location.origin, apiUrl],
-});
+
 
 export default initSentry;

--- a/src/core/integrations/sentry.ts
+++ b/src/core/integrations/sentry.ts
@@ -1,4 +1,7 @@
 import * as Sentry from '@sentry/react';
+import { Replay } from '@sentry/react';
+
+const apiUrl = process.env.REACT_APP_API_URL ?? '';
 
 const initSentry = (): void => {
   Sentry.init({
@@ -10,5 +13,10 @@ const initSentry = (): void => {
     environment: process.env.REACT_APP_ENVIRONMENT,
   })
 }
+
+// eslint-disable-next-line no-new
+new Replay({
+  networkDetailAllowUrls: [window.location.origin, apiUrl],
+});
 
 export default initSentry;

--- a/src/core/integrations/sentry.ts
+++ b/src/core/integrations/sentry.ts
@@ -7,9 +7,9 @@ const initSentry = (): void => {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-    tracesSampleRate: 1.0,
-    replaysSessionSampleRate: 1.0,
-    replaysOnErrorSampleRate: 1.0,
+    tracesSampleRate: .5,
+    replaysSessionSampleRate: .5,
+    replaysOnErrorSampleRate: .5,
     environment: process.env.REACT_APP_ENVIRONMENT,
   })
 }

--- a/src/shared/redux/core/saga.ts
+++ b/src/shared/redux/core/saga.ts
@@ -3,6 +3,7 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { coreActions, CoreData } from './slice';
 import jwtDecode from 'jwt-decode';
 import { NDAuthToken } from '../../types/ndAuthToken';
+import logError from '../../utils/logError';
 
 export function* watchStoreCoreDataAsync(
   action: PayloadAction<CoreData>
@@ -30,7 +31,7 @@ export function* watchStoreCoreDataAsync(
 
     yield put(coreActions.storeCoreData(coreData));
   } catch (error) {
-    console.log(error);
+    logError(error);
   }
 }
 

--- a/src/shared/redux/facility/saga.ts
+++ b/src/shared/redux/facility/saga.ts
@@ -6,6 +6,7 @@ import getMeFacility from '../../gql/me/queries';
 import { GetMeFacilityData, GetMeVariables } from '../../gql/me/types';
 import { ApolloQueryResult } from '@apollo/client';
 import { toast } from "react-toastify";
+import * as Sentry from '@sentry/react';
 
 export function* watchStoreFacilityDataAsync(): Generator<Effect, void> {
   try {
@@ -24,6 +25,7 @@ export function* watchStoreFacilityDataAsync(): Generator<Effect, void> {
       allQualificationTypes: response.data.allQualificationTypes
     }));
 
+    Sentry.setUser({ email: response.data.Me.email});
     yield put(coreActions.setLoadingStatus(false));
   } catch (error) {
     yield put(coreActions.setLoadingStatus(false));

--- a/src/shared/redux/facility/saga.ts
+++ b/src/shared/redux/facility/saga.ts
@@ -5,7 +5,6 @@ import { client } from '../../../core/providers/ApolloProvider';
 import getMeFacility from '../../gql/me/queries';
 import { GetMeFacilityData, GetMeVariables } from '../../gql/me/types';
 import { ApolloQueryResult } from '@apollo/client';
-import { toast } from "react-toastify";
 import * as Sentry from '@sentry/react';
 import logError from '../../utils/logError';
 

--- a/src/shared/redux/facility/saga.ts
+++ b/src/shared/redux/facility/saga.ts
@@ -7,6 +7,7 @@ import { GetMeFacilityData, GetMeVariables } from '../../gql/me/types';
 import { ApolloQueryResult } from '@apollo/client';
 import { toast } from "react-toastify";
 import * as Sentry from '@sentry/react';
+import logError from '../../utils/logError';
 
 export function* watchStoreFacilityDataAsync(): Generator<Effect, void> {
   try {
@@ -29,8 +30,8 @@ export function* watchStoreFacilityDataAsync(): Generator<Effect, void> {
     yield put(coreActions.setLoadingStatus(false));
   } catch (error) {
     yield put(coreActions.setLoadingStatus(false));
-    console.log(error);
-    toast.error(`There was an error fetching the facility data. Please reload the page.`);
+    const msg = `There was an error fetching the facility data. Please reload the page.`;
+    logError(error, msg);
   }
 }
 

--- a/src/shared/redux/shift/saga.ts
+++ b/src/shared/redux/shift/saga.ts
@@ -16,6 +16,8 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { toast } from "react-toastify";
 import { getAllCompletedShifts, getOverviewShift } from '../../gql/shift/queries';
 import { coreActions } from '../core/slice';
+import * as Sentry from '@sentry/react';
+import logError from '../../utils/logError';
 
 const mapShiftFormVariables = (payload: NewShiftPayload): CreateOverviewShiftVariables => ({
   breakTime: payload.breakDuration,
@@ -41,8 +43,8 @@ export function* watchPostShiftDataAsync(action: PayloadAction<NewShiftPayload>)
     yield put(shiftActions.storePostedShift(response.data.createOverviewShift));
     toast.success(`Shift created successfully`);
   } catch (error) {
-    toast.error(`There was an error creating the shift. Please try again.`);
-    console.log(error);
+    const msg = `There was an error creating the shift. Please try again.`
+    logError(error, msg);
   }
 }
 
@@ -61,8 +63,8 @@ export function* watchCancelShiftAsync(action: PayloadAction<CancelOverviewShift
     yield put(shiftActions.storeUpdatedShift(response.data.cancelShift));
     toast.success(`Shift cancelled successfully`);
   } catch (error) {
-    toast.error(`There was an error cancelling the shift. Please try again.`);
-    console.log(error);
+    const msg = `There was an error cancelling the shift. Please try again.`;
+    logError(error, msg);
   }
 }
 
@@ -84,8 +86,9 @@ export function* watchUpdateShiftAsync(action: PayloadAction<NewShiftPayload>): 
     yield put(shiftActions.resetShiftInfoToCopyOrEdit());
     toast.success(`Shift updated successfully`);
   } catch (error) {
-    toast.error(`There was an error updating this shift. Please try again.`);
-    console.log(error);
+    const msg = `There was an error updating this shift. Please try again.`;
+    logError(error, msg);
+
   }
 }
 
@@ -103,8 +106,8 @@ export function* watchGetCompletedShiftsAsync(action: PayloadAction<GetAllComple
 
     yield put(shiftActions.storeCompletedShifts(response.data.allCompletedShifts));
   } catch (error) {
-    toast.error(`There was an error retrieving the shift data. Please reload and try again.`);
-    console.log(error);
+    const msg = `There was an error retrieving the shift data. Please reload and try again.`;
+    logError(error, msg);
   }
 }
 
@@ -132,8 +135,8 @@ export function* watchGetOverviewShiftForCopyAsync(action: PayloadAction<GetOver
     yield put(coreActions.setLoadingStatus(false));
   } catch (error) {
     yield put(coreActions.setLoadingStatus(false));
-    toast.error(`There was an error setting your copied shift data. Please go back to the shift and try again.`);
-    console.log(error);
+    const msg = `There was an error setting your copied shift data. Please go back to the shift and try again.`;
+    logError(error, msg);
   }
 }
 

--- a/src/shared/redux/shift/saga.ts
+++ b/src/shared/redux/shift/saga.ts
@@ -16,7 +16,6 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { toast } from "react-toastify";
 import { getAllCompletedShifts, getOverviewShift } from '../../gql/shift/queries';
 import { coreActions } from '../core/slice';
-import * as Sentry from '@sentry/react';
 import logError from '../../utils/logError';
 
 const mapShiftFormVariables = (payload: NewShiftPayload): CreateOverviewShiftVariables => ({

--- a/src/shared/redux/shift/slice.ts
+++ b/src/shared/redux/shift/slice.ts
@@ -34,7 +34,7 @@ export const shiftSlice = createSlice({
   initialState,
   reducers: {
     storePostedShift: (state, action: PayloadAction<ShiftWithVisibilityToggle>) => {
-      state.postedOrEditedShifts = [...state.postedOrEditedShifts, { shift: action.payload, status: ShiftSessionStatus.NEW }];
+      state.postedOrEditedShifts = [{ shift: action.payload, status: ShiftSessionStatus.NEW }, ...state.postedOrEditedShifts];
     },
     postShiftAsync: (state, action: PayloadAction<NewShiftPayload>) => {},
     cancelShiftAsync: (state, action: PayloadAction<CancelOverviewShiftVariables>) => {},

--- a/src/shared/utils/logError.ts
+++ b/src/shared/utils/logError.ts
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/react';
+import { toast } from "react-toastify";
+
+const logError = (error: any, msg?: string): void => {
+  Sentry.captureException(error);
+  console.log(error);
+  if (msg !== null) toast.error(msg);
+}
+
+export default logError;


### PR DESCRIPTION
## What?
- Better Sentry logging configs.
  - Only sample replays when there is an error
  - Capture headers
  - Logs errors even in caught scenarios to help us troubleshoot and solve problems more quickly
- Sort the posted shifts list by newest at the top

## Why?
- We aren't in a place where sampling is useful or will be used in this app when there isn't an error so we don't want to waste our quota on it.
- Headers will increase resolution time, same with manually logging some errors.
- Sorting was a request from market leads.